### PR TITLE
changes to run the relevance prediction

### DIFF
--- a/src/article_relevance/gdd_api_query.py
+++ b/src/article_relevance/gdd_api_query.py
@@ -178,11 +178,15 @@ def get_new_gdd_articles(output_path,
     # initialize the resulting dataframe
     gdd_df = pd.DataFrame()
 
+    counter = 0
     for article in data:
+        counter +=1
         one_article_dict = {}
         one_article_dict['gddid'] = [article['_gddid']]
 
-        if article['identifier'][0]['type'] == 'doi':
+        if article['identifier'] == []:
+             one_article_dict['DOI'] = ['Non-DOI Article ID type']
+        elif article['identifier'][0]['type'] == 'doi':
             one_article_dict['DOI'] = [article['identifier'][0]['id']]
         else: 
             one_article_dict['DOI'] = ['Non-DOI Article ID type']
@@ -198,7 +202,7 @@ def get_new_gdd_articles(output_path,
 
 
     # ========== Get list of existing gddids from the parquet files =========
-    if auto_check_dup.lower() == "true":
+    if auto_check_dup == True:
         # Get the list of existing IDs from the Parquet files
         logger.info(f'auto_check_dup is True. Removing duplicates.')
 
@@ -280,7 +284,6 @@ def find_max_date_from_parquet(parquet_path):
 
 
 def main():
-
     opt = docopt(__doc__)
     doi_file_storage = opt["--doi_path"]
     parquet_file_path = opt["--parquet_path"]
@@ -312,7 +315,6 @@ def main():
     param_max_date = opt["--max_date"]
     param_term = opt["--term"]
 
-
     get_new_gdd_articles(output_path = doi_file_storage, 
                          parquet_path = parquet_file_path,
                          min_date = param_min_date, 
@@ -321,7 +323,6 @@ def main():
                          term = param_term,
                          auto_check_dup = param_auto_check_dup
                          )
-    
 
 if __name__ == "__main__":
     main()

--- a/src/article_relevance/relevance_prediction_parquet.py
+++ b/src/article_relevance/relevance_prediction_parquet.py
@@ -410,6 +410,7 @@ def prediction_export(input_df, output_path):
 
     # Write the Parquet file
     input_df.to_parquet(parquet_file_name)
+    input_df.to_csv(os.path.join(parquet_folder, f"article-relevance-prediction_{formatted_datetime}.csv"))
 
     # ===== log important information ======
     logger.info(f'Total number of DOI processed: {input_df.shape[0]}')
@@ -439,9 +440,9 @@ def main():
     metadata_df = crossref_extract(doi_list_file_path)
 
     preprocessed = data_preprocessing(metadata_df)
-
+    
     embedded = add_embeddings(preprocessed, 'text_with_abstract', model = 'allenai/specter2')
-
+    
     predicted = relevance_prediction(embedded, model_path, predict_thld = 0.5)
 
     if send_xdd =="True":
@@ -449,8 +450,6 @@ def main():
         predicted.loc[:, 'xdd_querystatus'] = predicted.apply(xdd_put_request, axis=1)
     
     prediction_export(predicted, output_path)
-
-
 
 if __name__ == "__main__":
     main()

--- a/src/pipeline/entity_extraction_pipeline.py
+++ b/src/pipeline/entity_extraction_pipeline.py
@@ -8,7 +8,7 @@ Options:
 --output_path=<output_path> The path to export the extracted entities to.
 --max_sentences=<max_sentences> The maximum number of sentences to extract entities from. [default: -1]
 --max_articles <max_articles> The maximum number of articles to extract entities from. [default: -1]
-"""
+""" 
 
 import os
 import sys


### PR DESCRIPTION
I made some changes to be able to run the relevance prediction. Some booleans were requested to do string methods, ie, True.lower() which would yield errors. 

There are also instances when doing the GDD call would bring in articles where the `identifier` was an empty list, this case was not handled and so, I would run into errors of translations. 

Added to save the file as a csv just to be able to load the file easier when doing comparisons - can remove this once the debugging is finished.